### PR TITLE
Terraform manual apply Github Action

### DIFF
--- a/.github/workflows/terraform-auto-approve.yaml
+++ b/.github/workflows/terraform-auto-approve.yaml
@@ -1,0 +1,41 @@
+name: Terraform Manual Apply
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to manually deploy in"
+        type: environment
+        required: true
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    name: Apply terraform
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: 'Create tfvars file'
+        run: |
+          echo '${{ vars.tfvars }}' > terraform/terraform.tfvars
+
+      - name: terraform apply
+        uses: dflook/terraform-apply@v1
+        with:
+          path: terraform
+          auto_approve: true
+          workspace: ${{ github.event.inputs.environment }}
+          backend_config: |
+            access_key=${{ secrets.spaces_access_token }}
+            secret_key=${{ secrets.spaces_secret_key }}
+            bucket=${{ secrets.tf_state_bucket }}
+          variables: |
+            do_token="${{ secrets.DO_TOKEN }}"
+            app_key="${{ secrets.app_key }}"
+          var_file: |
+            terraform/terraform.tfvars
+

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -36,5 +36,6 @@ jobs:
             bucket=${{ secrets.tf_state_bucket }}
           variables: |
             do_token="${{ secrets.DO_TOKEN }}"
+            app_key="${{ secrets.app_key }}"
           var_file: |
             terraform/terraform.tfvars


### PR DESCRIPTION
This PR adds a GitHub Action for ad-hoc Terraform applies, manually triggered for infrastructure deployments outside of a Pull Request, thus enhancing deployment flexibility.

It allows you to specify the target environment, which will load the relevant Terraform variables into the Action.