### PR TITLE
Disable Argo CD namespace creation & Manual apply Action

### DIFF
--- a/.github/workflows/terraform-auto-approve.yaml
+++ b/.github/workflows/terraform-auto-approve.yaml
@@ -1,0 +1,41 @@
+name: Terraform Manual Apply
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to manually deploy in"
+        type: environment
+        required: true
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    name: Apply terraform
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    environment: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: 'Create tfvars file'
+        run: |
+          echo '${{ vars.tfvars }}' > terraform/terraform.tfvars
+
+      - name: terraform apply
+        uses: dflook/terraform-apply@v1
+        with:
+          path: terraform
+          auto_approve: true
+          workspace: ${{ github.event.inputs.environment }}
+          backend_config: |
+            access_key=${{ secrets.spaces_access_token }}
+            secret_key=${{ secrets.spaces_secret_key }}
+            bucket=${{ secrets.tf_state_bucket }}
+          variables: |
+            do_token="${{ secrets.DO_TOKEN }}"
+            app_key="${{ secrets.app_key }}"
+          var_file: |
+            terraform/terraform.tfvars
+

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -36,5 +36,6 @@ jobs:
             bucket=${{ secrets.tf_state_bucket }}
           variables: |
             do_token="${{ secrets.DO_TOKEN }}"
+            app_key="${{ secrets.app_key }}"
           var_file: |
             terraform/terraform.tfvars

--- a/terraform/argocd/markwcodes.yaml
+++ b/terraform/argocd/markwcodes.yaml
@@ -13,7 +13,7 @@ applications:
         prune: true
         selfHeal: false
       syncOptions:
-        - CreateNamespace=true
+        - CreateNamespace=false
     info:
       - name: url
         value: https://staging.wilson.codes


### PR DESCRIPTION
- Disable namespace auto-creation in Argo CD
- Add a new GitHub Action for ad-hoc Terraform applies. Allows you to manually trigger infrastructure deployments outside of a Pull Request, thus enhancing deployment flexibility.